### PR TITLE
removed `(id)` placed `( )`. Voids as it should now and hides type notis

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
+/* eslint-disable no-empty-function */
 const { Plugin } = require('powercord/entities');
 const { typing } = require('powercord/webpack');
 
 module.exports = class SilentTyping extends Plugin {
-    startPlugin() {
-        this.oldStartTyping = typing.startTyping;
-        typing.startTyping = (id) => { };
-    }
-    pluginWillUnload() {
-        typing.startTyping = this.oldStartTyping;
-    }
+  startPlugin () {
+    this.oldStartTyping = typing.startTyping;
+    typing.startTyping = () => { };
+  }
+
+  pluginWillUnload () {
+    typing.startTyping = this.oldStartTyping;
+  }
 };


### PR DESCRIPTION
shows a lot of deletions due to soft-indention default on my linter. giggity for no-one seeing us run pc-commands in chat. 